### PR TITLE
Fix min node queryray closest

### DIFF
--- a/com.trove.common/Runtime/GeometryUtils.cs
+++ b/com.trove.common/Runtime/GeometryUtils.cs
@@ -173,7 +173,7 @@ namespace Trove
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IntersectsRay(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength)
+        public bool IntersectsRay(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength, out float tEntry)
         {
             float tMin = 0.0f;
             float tMax = float.MaxValue;
@@ -195,22 +195,25 @@ namespace Trove
 
                 if (tMin > tMax)
                 {
+                    tEntry = 0f;
                     return false;
                 }
             }
 
             if (tMax < 0.0f)
             {
+                tEntry = 0f;
                 return false;
             }
 
-            float distance = tMin;
-            if (distance <= rayLength)
-            {
-                return true;
-            }
+            tEntry = tMin;
+            return tMin <= rayLength;
+        }
 
-            return false;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IntersectsRay(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength)
+        {
+            return IntersectsRay(rayOrigin, rayDirectionNormalized, rayLength, out _);
         }
     }
 

--- a/com.trove.spatialqueries/Runtime/BVH.cs
+++ b/com.trove.spatialqueries/Runtime/BVH.cs
@@ -1002,7 +1002,8 @@ namespace Trove.SpatialQueries
         {
             NodeLevelDatas.Clear();
 
-            if (SortedNodes.Length < BVHUtils.NbLeavesPerNode)
+            // Special case for length 1 and 0
+            if (SortedNodes.Length <= 1)
             {
                 if (SortedNodes.Length > 0)
                 {

--- a/com.trove.spatialqueries/Runtime/BVH.cs
+++ b/com.trove.spatialqueries/Runtime/BVH.cs
@@ -375,16 +375,120 @@ namespace Trove.SpatialQueries
             where TCollector : unmanaged, IBVHQueryCollector<TNodeData>
         {
             collector.OnBeginQuery();
-        
-            if (SortedNodes.Length < 1)
-            {
+
+            if (SortedNodes.Length < 1) {
                 return false;
             }
-        
+
             Stack nodesStack = new Stack(256);
             int* nodesStackPtr = stackalloc int[nodesStack.Capacity];
             BVHNode* nodesPtr = SortedNodes.GetUnsafeReadOnlyPtr();
             TNodeData* leafDataPtr = LeafNodeDatas.GetUnsafeReadOnlyPtr();
+            int leafNodesCount = LeafNodeDatas.Length;
+
+            nodesStack.PushLast(nodesStackPtr, SortedNodes.Length - 1);  // start at root node;
+            while (nodesStack.PopLast(nodesStackPtr, out int nodeIndex)) {
+                BVHNode node = nodesPtr[nodeIndex];
+
+                if (!node.AABB.IntersectsRay(rayOrigin, rayDirectionNormalized, rayLength) || !node.IsValid())
+                    continue;
+
+                if (nodeIndex < leafNodesCount) {
+                    collector.AddNode(leafDataPtr[node.DataIndex]);
+                } else {
+                    for (int i = 0; i < BVHUtils.NbLeavesPerNode; i++) {
+                        nodesStack.PushLast(nodesStackPtr, node.DataIndex + i);
+                    }
+                }
+            }
+
+            return collector.HasFoundResults();
+        }
+
+        // Perform a raycast and fetch only the closest entity (no collector required)
+        // This version also gives the closest distance.
+        public unsafe bool QueryRayClosest(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength,
+            out TNodeData closestHit, out float closestDistance)
+        {
+            closestHit = default;
+            closestDistance = float.MaxValue;
+
+            if (SortedNodes.Length < 1) {
+                return false;
+            }
+
+            Stack nodesStack = new Stack(256);
+            int* nodesStackPtr = stackalloc int[nodesStack.Capacity];
+            BVHNode* nodesPtr = SortedNodes.GetUnsafeReadOnlyPtr();
+            TNodeData* leafDataPtr = LeafNodeDatas.GetUnsafeReadOnlyPtr();
+            int leafNodesCount = LeafNodeDatas.Length;
+
+            float currentMaxT = rayLength;
+            bool found = false;
+
+            nodesStack.PushLast(nodesStackPtr, SortedNodes.Length - 1);
+            while (nodesStack.PopLast(nodesStackPtr, out int nodeIndex)) {
+                BVHNode node = nodesPtr[nodeIndex];
+                if (!node.IsValid())
+                    continue;
+                if (!node.AABB.IntersectsRay(rayOrigin, rayDirectionNormalized, currentMaxT, out float tEntry))
+                    continue;
+                if (tEntry >= currentMaxT)
+                    continue;
+
+                if (nodeIndex < leafNodesCount) {
+                    currentMaxT = tEntry;
+                    closestDistance = tEntry;
+                    closestHit = leafDataPtr[node.DataIndex];
+                    found = true;
+                } else {
+                    // Ordered child traversal: push children in descending tEntry order so closest pops first
+                    int childBase = node.DataIndex;
+                    float4 ts = new float4(float.MaxValue);
+                    int4 idxs = new int4(-1);
+                    for (int i = 0; i < BVHUtils.NbLeavesPerNode; i++)
+                    {
+                        int ci = childBase + i;
+                        BVHNode child = nodesPtr[ci];
+                        if (!child.IsValid())
+                            continue;
+                        if (child.AABB.IntersectsRay(rayOrigin, rayDirectionNormalized, currentMaxT, out float t))
+                        {
+                            ts[i] = t;
+                            idxs[i] = ci;
+                        }
+                    }
+                    // Insertion sort, descending by t — smallest t ends up on top of stack
+                    for (int a = 0; a < 4; a++)
+                    {
+                        for (int b = a + 1; b < 4; b++)
+                        {
+                            if (ts[b] > ts[a])
+                            {
+                                (ts[a], ts[b]) = (ts[b], ts[a]);
+                                (idxs[a], idxs[b]) = (idxs[b], idxs[a]);
+                            }
+                        }
+                    }
+                    for (int i = 0; i < 4; i++)
+                    {
+                        if (idxs[i] >= 0) { nodesStack.PushLast(nodesStackPtr, idxs[i]); }
+                    }
+                }
+            }
+
+            return found;
+        }
+
+        // Returns true if any node was hit (useful for line-of-sight tests).
+        public unsafe bool QueryRayAny(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength)
+        {
+            if (SortedNodes.Length < 1)
+                return false;
+
+            Stack nodesStack = new Stack(256);
+            int* nodesStackPtr = stackalloc int[nodesStack.Capacity];
+            BVHNode* nodesPtr = SortedNodes.GetUnsafeReadOnlyPtr();
             int leafNodesCount = LeafNodeDatas.Length;
 
             nodesStack.PushLast(nodesStackPtr, SortedNodes.Length - 1);  // start at root node;
@@ -397,7 +501,7 @@ namespace Trove.SpatialQueries
 
                 if (nodeIndex < leafNodesCount)
                 {
-                    collector.AddNode(leafDataPtr[node.DataIndex]);
+                    return true;
                 }
                 else
                 {
@@ -408,7 +512,15 @@ namespace Trove.SpatialQueries
                 }
             }
 
-            return collector.HasFoundResults();
+            return false;
+        }
+
+
+        // Perform a raycast and fetch only the closest entity (no collector required)
+        // Use this version if you don't care about the distance.
+        public bool QueryRayClosest(float3 rayOrigin, float3 rayDirectionNormalized, float rayLength, out TNodeData closestHit)
+        {
+            return QueryRayClosest(rayOrigin, rayDirectionNormalized, rayLength, out closestHit, out _);
         }
 
         public bool QueryNearestNeighbor(float3 position, ref NearestNeighborResultCollector<TNodeData> collector, 


### PR DESCRIPTION
This PR has two main things:

1) I made a small change in BVHPrecomputedHierarchyJob.Execute() that fixes the error where: if there are 2 or 3 nodes inserted in the tree, only one of them gets added. I verified it with a gizmo showing all bvh nodes in the scene - before the fix with 3 entities, only one showed a box around it, and after the fix all 3 entities had boxes around them. I tested with 1, 2, and 4 as well.

2) I added 3 functions. 2 versions of QueryRayClosest(), and one QueryRayAny(). In order to make QueryRayClosest() more efficient, I had to make a tiny modification to AABB.IntersectRay() -- I needed the tEntry parameter. I overloaded it so that all calls to IntersectRay() simply call the new IntersectRay() and ignore the tEntry. Using the tEntry allowed me to keep shrinking the ray and prune out a lot of the ray-AABB tests, so it's faster than running a normal QueryRay() and using a collector. I tested it for a while using my selection/hover code in my game and it seemed to run fine - selecting entities in front of other entities.

Disclosure: I am not a BVH expert and I used Claude. I looked over the code as best I could and tested with it, but it's possible that there is a mistake that slipped through. I apologize for that, but I have so many things on my platet right now and I don't have a week to study the BVH implementation. The good news is that aside from the really tiny 2-3 node fix and the tiny change to AABB.IntersectRay() (which I can verify as correct), it's just 3 new functions which can't break anything existing so the risk is low. I will be using QueryRayClosest() for all my projectiles and QueryRayAny() for my turret LOS tests soon, so it'll be getting a lot of testing.